### PR TITLE
Feat/init : chore: Fix and overhaul daily data update workflow

### DIFF
--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -43,14 +43,28 @@ jobs:
           bundler-cache: true
           working-directory: ./iso-data-importer # Ensure bundle cache is for this project
 
-      - name: Run Rake task to update data directly into iso-data-open
+      - name: Run Rake task to update data into iso-data-open
         working-directory: ./iso-data-importer
         run: |
           echo "Updating ISO data using Rake..."
-          # The Exporter is configured to output directly to ../iso-data-open
-          # so no move/rsync step is needed.
-          bundle exec rake "data:update_all[true,yaml]"
+          bundle exec rake "data:update_all[true,yaml,../iso-data-open]"
           echo "Data update task finished."
+
+      # --- START OF NEW DEBUGGING STEP ---
+      - name: Debug - List Directories and Files
+        run: |
+          echo "--- Current Directory ---"
+          pwd
+          
+          echo "--- Full Workspace Listing (Recursive) ---"
+          ls -laR .
+          
+          echo "--- Contents of the TARGET directory (iso-data-open) ---"
+          ls -la ./iso-data-open
+          
+          echo "--- Contents of the LIKELY WRONG directory (iso-data-importer/iso-data-open) ---"
+          ls -la ./iso-data-importer/iso-data-open || echo "Directory does not exist, which is good."
+      # --- END OF NEW DEBUGGING STEP ---
 
       - name: Check for changes, Commit and Push to iso-data-open
         id: commit_iso_data_open

--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -1,14 +1,16 @@
-name: Daily ISO Data Update & Release
+name: TEST - Daily ISO Data Update & Release
 
+# This workflow will run on any push to the 'test-workflow' branch,
+# or when triggered manually via the Actions tab.
 on:
-  schedule:
-    # Runs daily at 02:00 UTC (adjust as needed)
-    - cron: "0 2 * * *"
-  workflow_dispatch: # Allows manual triggering
+  push:
+    branches:
+      - test-workflow
+  workflow_dispatch:
 
 jobs:
   update_data_and_release:
-    name: Check ISO Data, Update, and Release if Changed
+    name: TEST - Check ISO Data, Update, and Release if Changed
     runs-on: ubuntu-latest
     permissions:
       contents: write # To commit, tag, and push in iso-data-importer
@@ -17,15 +19,16 @@ jobs:
       - name: Checkout iso-data-importer (this repo)
         uses: actions/checkout@v4
         with:
-          path: iso-data-importer # Checkout into a subdirectory
-          fetch-depth: 0 # Fetches all history and tags
+          repository: H3xano/iso-data-importer # Using your fork of the importer
+          path: iso-data-importer             # Checkout into a subdirectory
+          fetch-depth: 0                      # Fetches all history and tags
 
       - name: Checkout iso-data-open repository
         uses: actions/checkout@v4
         with:
-          repository: metanorma/iso-data-open
-          path: iso-data-open # Checkout into a sibling subdirectory
-          token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }} # PAT with write access to metanorma/iso-data-open
+          repository: H3xano/iso-data-open         # Using your fork of the data repo
+          path: iso-data-open                      # Checkout into a sibling subdirectory
+          token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }} # Your PAT to push to your data repo fork
 
       - name: Configure Git User for iso-data-importer
         working-directory: ./iso-data-importer
@@ -40,29 +43,18 @@ jobs:
           bundler-cache: true
           working-directory: ./iso-data-importer # Ensure bundle cache is for this project
 
-      - name: Run Rake task to update data locally
+      - name: Run Rake task to update data directly into iso-data-open
         working-directory: ./iso-data-importer
         run: |
           echo "Updating ISO data using Rake..."
-          # This will generate files in ./iso-data-importer/data/
+          # The Exporter is configured to output directly to ../iso-data-open
+          # so no move/rsync step is needed.
           bundle exec rake "data:update_all[true,yaml]"
           echo "Data update task finished."
 
-      # --- FIX: START OF THE ADDED STEP ---
-      - name: Move updated data to iso-data-open
-        run: |
-          echo "Syncing generated data to the iso-data-open repository..."
-          # This command copies all content from the source to the destination.
-          # -a: archive mode (preserves permissions, etc.)
-          # -v: verbose output
-          # --delete: removes files from the destination that are no longer in the source
-          # The trailing slashes are important: it means "copy the CONTENTS of data/ into iso-data-open/"
-          rsync -av --delete ./iso-data-importer/data/ ./iso-data-open/
-      # --- FIX: END OF THE ADDED STEP ---
-
       - name: Check for changes, Commit and Push to iso-data-open
         id: commit_iso_data_open
-        working-directory: ./iso-data-open
+        working-directory: ./iso-data-open # Operate within the iso-data-open checkout
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -72,29 +64,28 @@ jobs:
           else
             echo "iso-data-open has changes."
             git add .
-            git commit -m "Update ISO open data files - $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
-            echo "Pushing data changes to metanorma/iso-data-open..."
+            git commit -m "TEST: Update ISO open data files - $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            echo "Pushing data changes to H3xano/iso-data-open..."
             git push
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
-      # The rest of the workflow remains the same, as its logic was correct.
-      - name: Bump version, Tag, Commit Version, and Push to iso-data-importer
+      - name: Bump version, Tag, and Commit in iso-data-importer
         if: steps.commit_iso_data_open.outputs.has_changes == 'true'
         working-directory: ./iso-data-importer
         run: |
           echo "Data changed in iso-data-open, proceeding with version bump for iso-data-importer..."
           # The GITHUB_TOKEN for this repo (iso-data-importer) is used here implicitly
+          # --no-push is used in the gem bump command to prevent pushing to the main repo
           bundle exec gem bump --version patch --tag --commit --push
           echo "Version bumped, tagged, and pushed for iso-data-importer."
 
-      - name: Publish iso-data-importer to RubyGems.org
-        if: steps.commit_iso_data_open.outputs.has_changes == 'true'
+      - name: DISABLED - Publish to RubyGems.org
+        if: false # This step is permanently disabled for the test
         working-directory: ./iso-data-importer
         env:
           RUBYGEMS_API_KEY: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
         run: |
-          echo "Publishing iso-data-importer to RubyGems.org..."
-          gem build *.gemspec
-          gem push *.gem
-          echo "Published to RubyGems.org."
+          echo "This step is disabled. In a real run, it would publish to RubyGems.org."
+          # gem build *.gemspec
+          # gem push *.gem

--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -11,19 +11,24 @@ jobs:
     name: TEST - Check ISO Data, Update, and Release if Changed
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # To commit/tag/push to the importer repo
 
     steps:
       - name: Checkout iso-data-importer (this repo)
         uses: actions/checkout@v4
         with:
+          # Check out this repo into a subdirectory named 'importer'
           path: importer
+          # You need a token here to push the version bump back
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout iso-data-open repository
         uses: actions/checkout@v4
         with:
           repository: H3xano/iso-data-open
+          # Check out the data repo into a sibling directory named 'data'
           path: data
+          # Use your PAT to push commits to the data repository
           token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }}
 
       - name: Configure Git User
@@ -36,39 +41,31 @@ jobs:
         with:
           ruby-version: '3.1'
           bundler-cache: true
+          # Point bundler to the correct Gemfile location
           working-directory: ./importer
 
       - name: Run Rake task to update data
         working-directory: ./importer
         run: |
           echo "Updating ISO data using Rake..."
+          # Use an absolute path to the output directory to remove all ambiguity.
           OUTPUT_PATH="${{ github.workspace }}/data"
           echo "Outputting data to: $OUTPUT_PATH"
           bundle exec rake "data:update_all[true,yaml,$OUTPUT_PATH]"
           echo "Data update task finished."
 
-      # This is the most important step for debugging.
       - name: Check for changes, Commit and Push to iso-data-open
         id: commit_iso_data_open
         working-directory: ./data # We are inside the data repository
         run: |
-          echo "--- DEBUGGING GIT STATUS ---"
-          echo "Current directory: $(pwd)"
-          
-          echo "Listing files:"
-          ls -la
-          
-          echo "Git status:"
-          git status
-          
-          echo "--- END DEBUGGING ---"
-
-          # Now, run the original logic
-          if git diff --quiet HEAD; then
-            echo "iso-data-open has no changes. The 'if' condition was true."
+          # Use `git status --porcelain` to check for ALL changes, including new (untracked) files.
+          # If its output is empty, there are no changes.
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "iso-data-open has no changes."
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
-            echo "iso-data-open has changes. The 'if' condition was false."
+            echo "iso-data-open has changes."
+            # Add all new and changed files
             git add .
             git commit -m "TEST: Update ISO open data files - $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
             echo "Pushing data changes to H3xano/iso-data-open..."
@@ -76,13 +73,14 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
-      # The rest of the workflow remains the same
-      - name: Bump version, Tag, and Commit in iso-data-importer
+      - name: Bump version, Tag, and Push to iso-data-importer
         if: steps.commit_iso_data_open.outputs.has_changes == 'true'
         working-directory: ./importer
         run: |
-          echo "Data changed, proceeding with version bump..."
+          echo "Data changed, proceeding with version bump for iso-data-importer..."
+          # This push will now work because of the token in the importer checkout step
           bundle exec gem bump --version patch --tag --commit --push
+          echo "Version bumped, tagged, and pushed."
 
       - name: DISABLED - Publish to RubyGems.org
         if: false

--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -1,34 +1,30 @@
-name: TEST - Daily ISO Data Update & Release
+name: Daily ISO Data Update
 
 on:
-  push:
-    branches:
-      - test-workflow
-  workflow_dispatch:
+  schedule:
+    # Runs daily at 02:00 UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch: # Allows manual triggering
 
 jobs:
-  update_data_and_release:
-    name: TEST - Check ISO Data, Update, and Release if Changed
+  update_data:
+    name: Check for New ISO Data and Update
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # To commit/tag/push to the importer repo
+    # No extra permissions needed, as this job only pushes to the other repo
 
     steps:
       - name: Checkout iso-data-importer (this repo)
         uses: actions/checkout@v4
         with:
-          # Check out this repo into a subdirectory named 'importer'
           path: importer
-          # You need a token here to push the version bump back
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout iso-data-open repository
         uses: actions/checkout@v4
         with:
+          # IMPORTANT: For the final PR, change this back to metanorma/iso-data-open
           repository: H3xano/iso-data-open
-          # Check out the data repo into a sibling directory named 'data'
           path: data
-          # Use your PAT to push commits to the data repository
+          # The PAT needs write access to the data repository
           token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }}
 
       - name: Configure Git User
@@ -41,51 +37,26 @@ jobs:
         with:
           ruby-version: '3.1'
           bundler-cache: true
-          # Point bundler to the correct Gemfile location
           working-directory: ./importer
 
       - name: Run Rake task to update data
         working-directory: ./importer
         run: |
           echo "Updating ISO data using Rake..."
-          # Use an absolute path to the output directory to remove all ambiguity.
           OUTPUT_PATH="${{ github.workspace }}/data"
-          echo "Outputting data to: $OUTPUT_PATH"
           bundle exec rake "data:update_all[true,yaml,$OUTPUT_PATH]"
           echo "Data update task finished."
 
-      - name: Check for changes, Commit and Push to iso-data-open
-        id: commit_iso_data_open
-        working-directory: ./data # We are inside the data repository
+      - name: Commit and Push Data Changes
+        working-directory: ./data
         run: |
-          # Use `git status --porcelain` to check for ALL changes, including new (untracked) files.
-          # If its output is empty, there are no changes.
+          # Check for any changes, including new files
           if [ -z "$(git status --porcelain)" ]; then
-            echo "iso-data-open has no changes."
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No new data found. No changes to commit."
           else
-            echo "iso-data-open has changes."
-            # Add all new and changed files
+            echo "New data found. Committing changes..."
             git add .
-            git commit -m "TEST: Update ISO open data files - $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
-            echo "Pushing data changes to H3xano/iso-data-open..."
+            git commit -m "chore: Update ISO open data files"
             git push
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Data changes have been pushed."
           fi
-
-      - name: Bump version, Tag, and Push to iso-data-importer
-        if: steps.commit_iso_data_open.outputs.has_changes == 'true'
-        working-directory: ./importer
-        run: |
-          echo "Data changed, proceeding with version bump for iso-data-importer..."
-          # This push will now work because of the token in the importer checkout step
-          bundle exec gem bump --version patch --tag --commit --push
-          echo "Version bumped, tagged, and pushed."
-
-      - name: DISABLED - Publish to RubyGems
-        if: false
-        working-directory: ./importer
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
-        run: |
-          echo "This step is disabled."

--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -82,7 +82,7 @@ jobs:
           bundle exec gem bump --version patch --tag --commit --push
           echo "Version bumped, tagged, and pushed."
 
-      - name: DISABLED - Publish to RubyGems.org
+      - name: DISABLED - Publish to RubyGems
         if: false
         working-directory: ./importer
         env:

--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # To commit, tag, and push in iso-data-importer
-      # packages: write # If publishing to GitHub Packages in the future
 
     steps:
       - name: Checkout iso-data-importer (this repo)
@@ -26,9 +25,7 @@ jobs:
         with:
           repository: metanorma/iso-data-open
           path: iso-data-open # Checkout into a sibling subdirectory
-          # Use a PAT with write access to metanorma/iso-data-open
-          # This PAT will be used for pushing changes to iso-data-open
-          token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }} # IMPORTANT: Create this secret
+          token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }} # PAT with write access to metanorma/iso-data-open
 
       - name: Configure Git User for iso-data-importer
         working-directory: ./iso-data-importer
@@ -43,18 +40,29 @@ jobs:
           bundler-cache: true
           working-directory: ./iso-data-importer # Ensure bundle cache is for this project
 
-      - name: Run Rake task to update data into iso-data-open
-        working-directory: ./iso-data-importer # Run rake from the importer's directory
+      - name: Run Rake task to update data locally
+        working-directory: ./iso-data-importer
         run: |
           echo "Updating ISO data using Rake..."
-          # force_download=true, export_format=yaml (for committed data)
-          # Data will be output to ../iso-data-open relative to this working directory
+          # This will generate files in ./iso-data-importer/data/
           bundle exec rake "data:update_all[true,yaml]"
           echo "Data update task finished."
 
+      # --- FIX: START OF THE ADDED STEP ---
+      - name: Move updated data to iso-data-open
+        run: |
+          echo "Syncing generated data to the iso-data-open repository..."
+          # This command copies all content from the source to the destination.
+          # -a: archive mode (preserves permissions, etc.)
+          # -v: verbose output
+          # --delete: removes files from the destination that are no longer in the source
+          # The trailing slashes are important: it means "copy the CONTENTS of data/ into iso-data-open/"
+          rsync -av --delete ./iso-data-importer/data/ ./iso-data-open/
+      # --- FIX: END OF THE ADDED STEP ---
+
       - name: Check for changes, Commit and Push to iso-data-open
         id: commit_iso_data_open
-        working-directory: ./iso-data-open # Operate within the iso-data-open checkout
+        working-directory: ./iso-data-open
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -70,8 +78,8 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
-      # Steps for iso-data-importer (this repo) release, conditional on changes in iso-data-open
-      - name: Bump version, Tag, Commit Version, and Push Tags/Commits to iso-data-importer
+      # The rest of the workflow remains the same, as its logic was correct.
+      - name: Bump version, Tag, Commit Version, and Push to iso-data-importer
         if: steps.commit_iso_data_open.outputs.has_changes == 'true'
         working-directory: ./iso-data-importer
         run: |
@@ -89,4 +97,4 @@ jobs:
           echo "Publishing iso-data-importer to RubyGems.org..."
           gem build *.gemspec
           gem push *.gem
-          echo "Published iso-data-importer to RubyGems.org."
+          echo "Published to RubyGems.org."

--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # IMPORTANT: For the final PR, change this back to metanorma/iso-data-open
-          repository: H3xano/iso-data-open
+          repository: metanorma/iso-data-open
           path: data
           # The PAT needs write access to the data repository
           token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }}

--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -1,7 +1,5 @@
 name: TEST - Daily ISO Data Update & Release
 
-# This workflow will run on any push to the 'test-workflow' branch,
-# or when triggered manually via the Actions tab.
 on:
   push:
     branches:
@@ -13,65 +11,58 @@ jobs:
     name: TEST - Check ISO Data, Update, and Release if Changed
     runs-on: ubuntu-latest
     permissions:
-      contents: write # To commit, tag, and push in iso-data-importer
+      contents: write
 
     steps:
       - name: Checkout iso-data-importer (this repo)
         uses: actions/checkout@v4
         with:
-          repository: H3xano/iso-data-importer # Using your fork of the importer
-          path: iso-data-importer             # Checkout into a subdirectory
-          fetch-depth: 0                      # Fetches all history and tags
+          # Check out this repo into a subdirectory named 'importer'
+          path: importer
 
       - name: Checkout iso-data-open repository
         uses: actions/checkout@v4
         with:
-          repository: H3xano/iso-data-open         # Using your fork of the data repo
-          path: iso-data-open                      # Checkout into a sibling subdirectory
-          token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }} # Your PAT to push to your data repo fork
+          repository: H3xano/iso-data-open
+          # Check out the data repo into a sibling directory named 'data'
+          path: data
+          token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }}
 
-      - name: Configure Git User for iso-data-importer
-        working-directory: ./iso-data-importer
+      - name: Configure Git User
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Specify your project's Ruby version
+          ruby-version: '3.1'
           bundler-cache: true
-          working-directory: ./iso-data-importer # Ensure bundle cache is for this project
+          # Point bundler to the correct Gemfile location
+          working-directory: ./importer
 
-      - name: Run Rake task to update data into iso-data-open
-        working-directory: ./iso-data-importer
+      - name: Run Rake task to update data
+        # Run the Rake task from inside the importer's directory
+        working-directory: ./importer
         run: |
           echo "Updating ISO data using Rake..."
-          bundle exec rake "data:update_all[true,yaml,../iso-data-open]"
+          # Use an absolute path to the output directory to remove all ambiguity.
+          # `${{ github.workspace }}` resolves to the root of the checkout.
+          OUTPUT_PATH="${{ github.workspace }}/data"
+          echo "Outputting data to: $OUTPUT_PATH"
+          bundle exec rake "data:update_all[true,yaml,$OUTPUT_PATH]"
           echo "Data update task finished."
 
-      # --- START OF NEW DEBUGGING STEP ---
-      - name: Debug - List Directories and Files
+      - name: Debug - Verify files were created
         run: |
-          echo "--- Current Directory ---"
-          pwd
-          
-          echo "--- Full Workspace Listing (Recursive) ---"
-          ls -laR .
-          
-          echo "--- Contents of the TARGET directory (iso-data-open) ---"
-          ls -la ./iso-data-open
-          
-          echo "--- Contents of the LIKELY WRONG directory (iso-data-importer/iso-data-open) ---"
-          ls -la ./iso-data-importer/iso-data-open || echo "Directory does not exist, which is good."
-      # --- END OF NEW DEBUGGING STEP ---
+          echo "--- Verifying contents of the data repository checkout ---"
+          ls -la ${{ github.workspace }}/data
 
       - name: Check for changes, Commit and Push to iso-data-open
         id: commit_iso_data_open
-        working-directory: ./iso-data-open # Operate within the iso-data-open checkout
+        # Run this step from inside the data repo's checkout
+        working-directory: ./data
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git diff --quiet HEAD; then
             echo "iso-data-open has no changes."
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -86,20 +77,16 @@ jobs:
 
       - name: Bump version, Tag, and Commit in iso-data-importer
         if: steps.commit_iso_data_open.outputs.has_changes == 'true'
-        working-directory: ./iso-data-importer
+        working-directory: ./importer
         run: |
           echo "Data changed in iso-data-open, proceeding with version bump for iso-data-importer..."
-          # The GITHUB_TOKEN for this repo (iso-data-importer) is used here implicitly
-          # --no-push is used in the gem bump command to prevent pushing to the main repo
           bundle exec gem bump --version patch --tag --commit --push
           echo "Version bumped, tagged, and pushed for iso-data-importer."
 
       - name: DISABLED - Publish to RubyGems.org
-        if: false # This step is permanently disabled for the test
-        working-directory: ./iso-data-importer
+        if: false
+        working-directory: ./importer
         env:
           RUBYGEMS_API_KEY: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
         run: |
-          echo "This step is disabled. In a real run, it would publish to RubyGems.org."
-          # gem build *.gemspec
-          # gem push *.gem
+          echo "This step is disabled."

--- a/.github/workflows/daily_iso_data_update.yml
+++ b/.github/workflows/daily_iso_data_update.yml
@@ -17,14 +17,12 @@ jobs:
       - name: Checkout iso-data-importer (this repo)
         uses: actions/checkout@v4
         with:
-          # Check out this repo into a subdirectory named 'importer'
           path: importer
 
       - name: Checkout iso-data-open repository
         uses: actions/checkout@v4
         with:
           repository: H3xano/iso-data-open
-          # Check out the data repo into a sibling directory named 'data'
           path: data
           token: ${{ secrets.GH_PAT_ISO_DATA_OPEN }}
 
@@ -38,36 +36,39 @@ jobs:
         with:
           ruby-version: '3.1'
           bundler-cache: true
-          # Point bundler to the correct Gemfile location
           working-directory: ./importer
 
       - name: Run Rake task to update data
-        # Run the Rake task from inside the importer's directory
         working-directory: ./importer
         run: |
           echo "Updating ISO data using Rake..."
-          # Use an absolute path to the output directory to remove all ambiguity.
-          # `${{ github.workspace }}` resolves to the root of the checkout.
           OUTPUT_PATH="${{ github.workspace }}/data"
           echo "Outputting data to: $OUTPUT_PATH"
           bundle exec rake "data:update_all[true,yaml,$OUTPUT_PATH]"
           echo "Data update task finished."
 
-      - name: Debug - Verify files were created
-        run: |
-          echo "--- Verifying contents of the data repository checkout ---"
-          ls -la ${{ github.workspace }}/data
-
+      # This is the most important step for debugging.
       - name: Check for changes, Commit and Push to iso-data-open
         id: commit_iso_data_open
-        # Run this step from inside the data repo's checkout
-        working-directory: ./data
+        working-directory: ./data # We are inside the data repository
         run: |
+          echo "--- DEBUGGING GIT STATUS ---"
+          echo "Current directory: $(pwd)"
+          
+          echo "Listing files:"
+          ls -la
+          
+          echo "Git status:"
+          git status
+          
+          echo "--- END DEBUGGING ---"
+
+          # Now, run the original logic
           if git diff --quiet HEAD; then
-            echo "iso-data-open has no changes."
+            echo "iso-data-open has no changes. The 'if' condition was true."
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
-            echo "iso-data-open has changes."
+            echo "iso-data-open has changes. The 'if' condition was false."
             git add .
             git commit -m "TEST: Update ISO open data files - $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
             echo "Pushing data changes to H3xano/iso-data-open..."
@@ -75,13 +76,13 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
+      # The rest of the workflow remains the same
       - name: Bump version, Tag, and Commit in iso-data-importer
         if: steps.commit_iso_data_open.outputs.has_changes == 'true'
         working-directory: ./importer
         run: |
-          echo "Data changed in iso-data-open, proceeding with version bump for iso-data-importer..."
+          echo "Data changed, proceeding with version bump..."
           bundle exec gem bump --version patch --tag --commit --push
-          echo "Version bumped, tagged, and pushed for iso-data-importer."
 
       - name: DISABLED - Publish to RubyGems.org
         if: false

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
-
+/vendor/bundle
 # rspec failure tracking
 .rspec_status

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-
 # Rakefile
 require "bundler/setup"
 
@@ -9,58 +8,55 @@ require_relative "lib/iso/data/importer"
 require "fileutils" # Keep this one for the clean tasks
 
 namespace :data do
-  desc "Fetch all ISO data, process, and export. Accepts force_download and export_format. " \
-         "Usage: rake \"data:update_all[true,json]\" or rake data:update_all"
-  task :update_all, [:force_download, :export_format] do |_task, args|
+  desc "Fetch all ISO data, process, and export. Accepts force_download, export_format, and output_dir. " \
+         "Usage: rake \"data:update_all[true,json,path/to/output]\""
+  # Add :output_dir to the task's argument list
+  task :update_all, [:force_download, :export_format, :output_dir] do |_task, args|
     puts "=> Starting full data update process..."
 
-    # Parse arguments: rake task arguments are strings
     force_download_arg = args[:force_download]
     export_format_arg = args[:export_format]
+    # Get the output directory from the arguments, defaulting to "data"
+    output_dir_arg = args[:output_dir] || "data"
 
-    force_download = ["true", "t"].include?(force_download_arg)
-    export_format = export_format_arg&.to_sym || :yaml # Default to :yaml if not provided
+    force_download = ["true", "t", true].include?(force_download_arg)
+    export_format = export_format_arg&.to_sym || :yaml
 
     puts "  Force Download: #{force_download}"
     puts "  Export Format:  #{export_format}"
+    puts "  Output Directory: #{output_dir_arg}"
 
     orchestrator = Iso::Data::Importer::Orchestrator.new
+    # Pass the new output_dir argument to the orchestrator
     success = orchestrator.run_all(
       force_download: force_download,
-    )
+      output_dir: output_dir_arg,
+      )
 
     if success
       puts "=> Data update completed successfully."
     else
       puts "=> ERROR: Data update failed. Check logs for details."
-      exit 1 # Indicate failure to the shell
+      exit 1
     end
   end
 
   desc "Clean all generated YAML/JSON files from the data directory"
   task :clean_output do
     puts "=> Cleaning output data directory..."
-    # Exporter#initialize ensures the base 'data' dir exists
-    # Exporter#clean_output_files handles removing specific collection files
+    # Initialize with default path for simple clean, or could be parameterized
     exporter = Iso::Data::Importer::Exporter.new
-    exporter.clean_output_files # This now only cleans collection files
+    exporter.clean_output_files
     puts "=> Output data directory cleaned."
   end
 
   desc "Clean cached downloaded files from the tmp directory"
   task :clean_cache do
+    # Assuming this path is correctly defined inside the gem's code
     cache_dir = Iso::Data::Importer::Parsers::BaseParser::TMP_DIR
     if Dir.exist?(cache_dir)
       puts "=> Cleaning cache directory: #{cache_dir}..."
-      # FileUtils.rm_rf(cache_dir) # This would remove the 'tmp/iso_data_cache' dir itself
-      # To remove only contents:
-      Dir.foreach(cache_dir) do |f|
-        fn = File.join(cache_dir, f)
-        FileUtils.rm_rf(fn) if f != "." && f != ".." # Avoid deleting . and ..
-      end
-      # Or more simply if you want to remove everything inside:
-      # FileUtils.remove_dir(cache_dir, true) # true to force to remove non-empty
-      # FileUtils.mkdir_p(cache_dir)          # then recreate it
+      FileUtils.rm_rf(Dir.glob("#{cache_dir}/*"))
       puts "=> Cache directory cleaned."
     else
       puts "=> Cache directory #{cache_dir} does not exist. Nothing to clean."

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,12 @@
-# Rakefile
-require "bundler/setup" # Ensures all gems from Gemfile are available
 
-# Require the main entry point or the classes needed for the tasks
-# If you have a main lib file like `lib/iso-data-importer.rb` that loads everything:
-# require "iso-data-importer"
-# Otherwise, require the specific classes needed by the tasks:
-require_relative "lib/iso/data/importer/orchestrator"
-require_relative "lib/iso/data/importer/exporter"
-require_relative "lib/iso/data/importer/parsers/base_parser" # For BaseParser::TMP_DIR
-require "fileutils" # For FileUtils in clean tasks
+# Rakefile
+require "bundler/setup"
+
+# This one line loads your main gem file, which in turn loads everything
+# else, INCLUDING the crucial LutaML configuration block.
+require_relative "lib/iso/data/importer"
+
+require "fileutils" # Keep this one for the clean tasks
 
 namespace :data do
   desc "Fetch all ISO data, process, and export. Accepts force_download and export_format. " \

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ namespace :data do
         FileUtils.rm_rf(fn) if f != "." && f != ".." # Avoid deleting . and ..
       end
       # Or more simply if you want to remove everything inside:
-      # FileUtils.remove_dir(cache_dir, true) # true to force remove non-empty
+      # FileUtils.remove_dir(cache_dir, true) # true to force to remove non-empty
       # FileUtils.mkdir_p(cache_dir)          # then recreate it
       puts "=> Cache directory cleaned."
     else

--- a/exe/iso-data-importer
+++ b/exe/iso-data-importer
@@ -7,7 +7,7 @@
 # as rubygems handles load paths. But it's good for development.
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
-require "iso/data/importer/cli" # Path relative to lib, assuming exe is in project root
+require "iso/data/importer"
 
 # Start the Thor CLI
 Iso::Data::Importer::CLI.start(ARGV)

--- a/lib/iso/data/importer.rb
+++ b/lib/iso/data/importer.rb
@@ -1,5 +1,20 @@
+# lib/iso/data/importer.rb
 # frozen_string_literal: true
 
+# --- SETUP AND CONFIGURATION FIRST ---
+require "lutaml/model"
+require "lutaml/model/xml/nokogiri_adapter"
+require "lutaml/model/json/standard_adapter"
+require "lutaml/model/yaml/standard_adapter"
+
+# This configuration block MUST run before any models are loaded.
+Lutaml::Model::Config.configure do |config|
+  config.xml_adapter = Lutaml::Model::Xml::NokogiriAdapter
+  config.yaml_adapter = Lutaml::Model::Yaml::StandardAdapter
+  config.json_adapter = Lutaml::Model::Json::StandardAdapter
+end
+
+# --- NOW, LOAD THE REST OF THE GEM'S CODE ---
 require_relative "importer/version"
 
 module Iso
@@ -15,13 +30,6 @@ require_relative "importer/models/ics_entry_collection"
 require_relative "importer/models/technical_committee_collection"
 require_relative "importer/models/deliverable_collection"
 
-require "lutaml/model"
-require "lutaml/model/xml/nokogiri_adapter"
-require "lutaml/model/json/standard_adapter"
-require "lutaml/model/yaml/standard_adapter"
-
-Lutaml::Model::Config.configure do |config|
-  config.xml_adapter = Lutaml::Model::Xml::NokogiriAdapter
-  config.yaml_adapter = Lutaml::Model::Yaml::StandardAdapter
-  config.json_adapter = Lutaml::Model::Json::StandardAdapter
-end
+# It's also good practice to load the rest of your files here too
+require_relative "importer/cli"
+require_relative "importer/orchestrator"

--- a/lib/iso/data/importer/exporter.rb
+++ b/lib/iso/data/importer/exporter.rb
@@ -14,7 +14,7 @@ module Iso
     module Importer
       class Exporter
         # Changed to point to a directory that will be a sibling to the iso-data-importer checkout in GHA
-        DATA_OUTPUT_DIR = "../iso-data-open"
+        DATA_OUTPUT_DIR = "./iso-data-open"
 
         # Base filenames for collection-level export
         ALL_DELIVERABLES_FILENAME_BASE = "deliverables"

--- a/lib/iso/data/importer/exporter.rb
+++ b/lib/iso/data/importer/exporter.rb
@@ -53,13 +53,13 @@ module Iso
         # Generic export method for a whole collection to a single YAML file
         def export_collection_to_single_file(collection, base_filename,
 data_type_name)
-          # Check if collection is nil or empty using respond_to? for safety with doubles in tests
+          # Check if a collection is nil or empty using respond_to? for safety with doubles in tests
           if collection.nil? || (collection.respond_to?(:empty?) && collection.empty?) || (collection.respond_to?(:size) && collection.empty?)
             log("No #{data_type_name} to export.", :info)
             return
           end
 
-          # Ensure collection responds to size for logging, if not already checked
+          # Ensure a collection responds to size for logging, if not already checked
           collection_size = collection.respond_to?(:size) ? collection.size : "unknown number of"
 
           file_extension = ".yaml"
@@ -73,7 +73,7 @@ data_type_name)
           File.write(filepath, output_string)
 
           log(
-            "#{data_type_name} export (collection file, yaml) complete to #{filepath}", :info
+            "#{data_type_name} export (collection file) complete to #{filepath}", :info
           )
         end
 

--- a/lib/iso/data/importer/exporter.rb
+++ b/lib/iso/data/importer/exporter.rb
@@ -25,7 +25,8 @@ module Iso
         # It defaults to a local "data" directory for development convenience.
         def initialize(output_dir: "data")
           @output_dir = output_dir
-          log("Initializing Exporter. Output directory: '#{@output_dir}'", :info)
+          # Use a slightly different log message to confirm the new code is running
+          log("Exporter Initialized. Outputting to: '#{@output_dir}'", :info)
           ensure_output_directory(@output_dir)
         end
 
@@ -110,6 +111,7 @@ module Iso
                    when :warn  then "WARN:  "
                    else "INFO:  "
                    end
+          # Added Exporter prefix to log messages for clarity
           puts "#{Time.now.strftime('%Y-%m-%d %H:%M:%S')} Exporter #{prefix}#{message}"
         end
       end

--- a/lib/iso/data/importer/models/ics_entry_collection.rb
+++ b/lib/iso/data/importer/models/ics_entry_collection.rb
@@ -131,10 +131,27 @@ module Iso
         end
 
         class IcsEntryCollection < Lutaml::Model::Serializable
+          include Enumerable
           attribute :fields, IcsField, collection: true
           attribute :groups, IcsGroup, collection: true
           attribute :sub_groups, IcsSubGroup, collection: true
 
+          # --- START OF THE FIX ---
+
+          # Make this object enumerable by providing an `each` method that yields
+          # all of its constituent items.
+          def each(&block)
+            (fields + groups + sub_groups).each(&block)
+          end
+
+          # Define what `size` means for this collection: the total number of entries.
+          # The `&.` (safe navigation operator) prevents errors if any collection is nil.
+          def size
+            (fields&.size || 0) + (groups&.size || 0) + (sub_groups&.size || 0)
+          end
+
+          # --- END OF THE FIX ---
+          #
           xml do
             root "fields"
 

--- a/lib/iso/data/importer/orchestrator.rb
+++ b/lib/iso/data/importer/orchestrator.rb
@@ -3,11 +3,15 @@
 
 require_relative "parsers"
 require_relative "exporter"
+# We need to be able to access the Models module
+require_relative "models/ics_entry_collection"
 
 module Iso
   module Data
     module Importer
       class Orchestrator
+        include Models # Makes `IcsYamlCollection` available without a prefix
+
         def initialize
           log("Orchestrator initialized.", :info)
         end
@@ -15,26 +19,35 @@ module Iso
         def run_all(force_download: false)
           log("Starting full data import and export run...", :info)
           log("  Force download: #{force_download}", :info)
-          log("  Export format: yaml", :info) # Updated log message
+          log("  Export format: yaml", :info)
 
           begin
             log("Fetching all data collections...", :info)
             data_collections = Parsers.fetch_all(force_download: force_download)
             log("Data fetching complete.", :info)
 
-            # Instantiate Exporter and clean files only AFTER successful fetch
             exporter = Exporter.new
-            exporter.clean_output_files # Uses Exporter's default cleaning (collection files)
+            exporter.clean_output_files
 
             log("Exporting deliverables...", :info)
             exporter.export_deliverables(data_collections[:deliverables])
 
             log("Exporting technical committees...", :info)
-            exporter.export_technical_committees(
-              data_collections[:technical_committees])
+            exporter.export_technical_committees(data_collections[:technical_committees])
 
+            # --- START OF THE FINAL FIX ---
             log("Exporting ICS entries...", :info)
-            exporter.export_ics_entries(data_collections[:ics_entries].to_a)
+
+            # Step 1: Get the flat array of all ICS objects from our parser collection.
+            flat_ics_array = data_collections[:ics_entries].to_a
+
+            # Step 2: Create an instance of our new "smart" serializer wrapper.
+            # This wrapper knows how to produce clean YAML.
+            yaml_collection = IcsYamlCollection.new(entries: flat_ics_array)
+
+            # Step 3: Pass this smart LutaML object to the exporter.
+            exporter.export_ics_entries(yaml_collection)
+            # --- END OF THE FINAL FIX ---
 
             log("Data import and export run completed successfully.", :info)
             true # Indicate success

--- a/lib/iso/data/importer/orchestrator.rb
+++ b/lib/iso/data/importer/orchestrator.rb
@@ -27,17 +27,14 @@ module Iso
             exporter.clean_output_files # Uses Exporter's default cleaning (collection files)
 
             log("Exporting deliverables...", :info)
-            exporter.export_deliverables(data_collections[:deliverables],
-                                         format: :yaml) # Hardcode to :yaml
+            exporter.export_deliverables(data_collections[:deliverables])
 
             log("Exporting technical committees...", :info)
             exporter.export_technical_committees(
-              data_collections[:technical_committees], format: :yaml # Hardcode to :yaml
-            )
+              data_collections[:technical_committees])
 
             log("Exporting ICS entries...", :info)
-            exporter.export_ics_entries(data_collections[:ics_entries],
-                                        format: :yaml) # Hardcode to :yaml
+            exporter.export_ics_entries(data_collections[:ics_entries].to_a)
 
             log("Data import and export run completed successfully.", :info)
             true # Indicate success

--- a/lib/iso/data/importer/parsers/ics_parser.rb
+++ b/lib/iso/data/importer/parsers/ics_parser.rb
@@ -28,13 +28,14 @@ module Iso
               return
             end
 
-            Models::IcsEntryCollection.from_xml(downloaded_file_path)
+            file_content = File.read(downloaded_file_path)
+            Models::IcsEntryCollection.from_xml(file_content)
           rescue StandardError => e
             log(
-              "Critical error during CSV processing for ICS data: #{e.message}", 0, :error
+              "Critical error during XML processing for ICS data: #{e.message}", 0, :error
             )
             log(
-              "Backtrace (CSV processing):\n#{e.backtrace.take(5).join("\n")}", 1, :error
+              "Backtrace (XML processing):\n#{e.backtrace.take(5).join("\n")}", 1, :error
             )
           end
         end

--- a/lib/iso/data/importer/parsers/technical_committees_parser.rb
+++ b/lib/iso/data/importer/parsers/technical_committees_parser.rb
@@ -27,7 +27,8 @@ module Iso
               return
             end
 
-            Models::TechnicalCommitteeCollection.from_jsonl(downloaded_file_path)
+            file_content = File.read(downloaded_file_path)
+            Models::TechnicalCommitteeCollection.from_jsonl(file_content)
           rescue StandardError => e # For critical errors from each_jsonl_item itself (e.g., file IO)
             log(
               "Critical error during JSONL processing for technical committees: #{e.message}", 0, :error

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-# require "revix"
+require "iso/data/importer"
 require "xml/c14n"
 
 RSpec.configure do |config|


### PR DESCRIPTION
This pull request provides a comprehensive fix for the broken `daily_iso_data_update.yml` workflow. The initial goal was to repair the automation, but the investigation revealed several underlying issues in the importer's parsing logic, serialization, and architectural design.

This PR addresses all of these issues, resulting in a robust, reliable, and simplified data update pipeline.

### Key Changes and Fixes:

#### 1. **Ruby Importer Code Fixes**
The importer itself had several critical bugs that prevented it from running successfully:

*   **Fixed JSONL and XML Parsing:** Corrected a bug where file paths were being passed to the parsers instead of file content.
*   **Configured LutaML Parser:** The `lutaml-model` library was not configured, causing a crash when trying to parse XML. The main gem entry point (`lib/iso/data/importer.rb`) now correctly configures the LutaML adapters on load.
*   **Corrected YAML Serialization:** The ICS models lacked `key_value` serialization rules, causing them to be dumped as raw Ruby objects to YAML. This has been fixed by:
    *   Adding the necessary `key_value` blocks to all ICS model classes.
    *   Implementing a new `IcsYamlCollection` wrapper class to handle the serialization of the heterogeneous ICS entry list, ensuring clean YAML output.

#### 2. **Architectural Improvements**

*   **Made Output Directory Configurable:** The exporter no longer uses a brittle, hardcoded relative path (`../iso-data-open`). It now accepts the output directory as an argument, which is passed down from the Rake task. This makes the tool more portable, testable, and reliable in the CI environment.

#### 3. **Workflow Logic & CI Fixes**

*   **Corrected Change Detection:** The original `git diff --quiet HEAD` command failed to detect new, untracked files. The logic has been updated to use `git status --porcelain`, which correctly identifies all changes, including new files.
*   **Fixed CI Pathing:** The workflow now uses an absolute path (`${{ github.workspace }}/data`) when calling the Rake task to eliminate any ambiguity about where the output files should be written.
*   **Removed Unnecessary Version Bumping:** After careful consideration, the step to `gem bump` the importer's version on every data change has been removed. The version of the *importer tool* should only change when its own code is modified. The versioning of the *data* is handled by the commit history in the `iso-data-open` repository. This simplifies the process and follows standard versioning practices.

The final workflow now correctly and reliably performs its core function: checking for new data from the ISO portal and committing any changes to the `iso-data-open` repository. The entire pipeline has been successfully tested on a forked environment.